### PR TITLE
Font loading

### DIFF
--- a/Allinson-StyleGuide.podspec
+++ b/Allinson-StyleGuide.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name        = "Allinson-StyleGuide"
-  s.version     = "0.9.0"
+  s.version     = "0.9.2"
   s.summary     = "Colors, fonts and images used across the Allinson.ca suite of applications"
-  s.homepage    = "https://github.com/ChrisAllinson/StyleGuide-iOS/tree/0.9.0"
+  s.homepage    = "https://github.com/ChrisAllinson/StyleGuide-iOS/tree/0.9.2"
   s.license     = { :type => "MIT", :file => "LICENSE.txt" }
   s.authors     = { "ChrisAllinson" => "allinson.ca@hotmail.com" }
 
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
   s.source   = { :git => "https://github.com/ChrisAllinson/StyleGuide-iOS.git", :branch => "master", :tag => s.version }
   s.source_files = "LICENSE.txt", "README.md", "StyleGuide-iOS/StyleGuide/**/*.{h,m,swift,plist}"
-  s.resources = "StyleGuide-iOS/StyleGuide/**/*.{png,jpeg,jpg,storyboard,xib,xcassets,json,txt,md,ttf}"
+  s.resources = "StyleGuide-iOS/StyleGuide/**/*.{jpg,jpeg,png,json,md,ttf,txt,xcassets,xib,storyboard}"
 end

--- a/StyleGuide-iOS.xcodeproj/project.pbxproj
+++ b/StyleGuide-iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		56767CCF2C0269BF00300D1B /* UIImage+Allinson.m in Sources */ = {isa = PBXBuildFile; fileRef = 56767CCD2C0269BF00300D1B /* UIImage+Allinson.m */; };
 		56767CD12C0269D500300D1B /* UIImage+Allinson.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56767CD02C0269D500300D1B /* UIImage+Allinson.swift */; };
 		56767CDB2C026FFD00300D1B /* README (Images).md in Resources */ = {isa = PBXBuildFile; fileRef = 56767CDA2C026FFD00300D1B /* README (Images).md */; };
+		56767CDD2C02895000300D1B /* AllinsonStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56767CDC2C02895000300D1B /* AllinsonStyleGuide.swift */; };
 		5695F76D2BF67E5900BA3D64 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695F76C2BF67E5900BA3D64 /* AppDelegate.swift */; };
 		5695F76F2BF67E5900BA3D64 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695F76E2BF67E5900BA3D64 /* SceneDelegate.swift */; };
 		5695F7712BF67E5900BA3D64 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695F7702BF67E5900BA3D64 /* ViewController.swift */; };
@@ -63,6 +64,7 @@
 		56767CCE2C0269BF00300D1B /* UIImage+Allinson.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Allinson.h"; sourceTree = "<group>"; };
 		56767CD02C0269D500300D1B /* UIImage+Allinson.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Allinson.swift"; sourceTree = "<group>"; };
 		56767CDA2C026FFD00300D1B /* README (Images).md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = "README (Images).md"; sourceTree = "<group>"; };
+		56767CDC2C02895000300D1B /* AllinsonStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllinsonStyleGuide.swift; sourceTree = "<group>"; };
 		5695F7692BF67E5900BA3D64 /* StyleGuide-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "StyleGuide-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5695F76C2BF67E5900BA3D64 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5695F76E2BF67E5900BA3D64 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 		56E2A3692BFAA30700D07139 /* StyleGuide */ = {
 			isa = PBXGroup;
 			children = (
+				56767CDC2C02895000300D1B /* AllinsonStyleGuide.swift */,
 				56E2A36A2BFAA34B00D07139 /* Colors */,
 				56E2A3962BFAA40A00D07139 /* Images */,
 				56E2A37D2BFAA40200D07139 /* Fonts */,
@@ -401,6 +404,7 @@
 				56E2A3AB2BFBD7EF00D07139 /* UIFont+Allinson.m in Sources */,
 				56767CD12C0269D500300D1B /* UIImage+Allinson.swift in Sources */,
 				56767CCF2C0269BF00300D1B /* UIImage+Allinson.m in Sources */,
+				56767CDD2C02895000300D1B /* AllinsonStyleGuide.swift in Sources */,
 				5695F76D2BF67E5900BA3D64 /* AppDelegate.swift in Sources */,
 				5695F76F2BF67E5900BA3D64 /* SceneDelegate.swift in Sources */,
 				56E2A38A2BFAA40200D07139 /* UIFont+Allinson.swift in Sources */,

--- a/StyleGuide-iOS/AppDelegate.swift
+++ b/StyleGuide-iOS/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        AllinsonStyleGuide.loadFonts()
         return true
     }
 

--- a/StyleGuide-iOS/StyleGuide/AllinsonStyleGuide.swift
+++ b/StyleGuide-iOS/StyleGuide/AllinsonStyleGuide.swift
@@ -1,0 +1,25 @@
+//
+//  AllinsonStyleGuide.swift
+//  StyleGuide-iOS
+//
+//  Created by Chris Allinson on 2024-05-25.
+//
+
+import UIKit
+
+@objc
+public class AllinsonStyleGuide: NSObject {
+    
+    // public methods
+    
+    @objc
+    public static func loadFonts() {
+        guard let fontURL = Bundle(for: AllinsonStyleGuide.self).url(forResource: "OpenSans-Regular", withExtension: "ttf"),
+              let fontData = try? Data(contentsOf: fontURL) as CFData,
+              let provider = CGDataProvider(data: fontData),
+              let font = CGFont(provider) else {
+                return
+        }
+        CTFontManagerRegisterGraphicsFont(font, nil)
+    }
+}

--- a/StyleGuide-iOS/StyleGuide/Colors/README (Colors).md
+++ b/StyleGuide-iOS/StyleGuide/Colors/README (Colors).md
@@ -1,4 +1,7 @@
 
+# COLORS
+
+
 Select colors in Interface Builder via the **Named Colors** section of an element's **Color** dropdown.
 **Allinson_header_brown**
 **Allinson_body_brown**

--- a/StyleGuide-iOS/StyleGuide/Fonts/README (Fonts).md
+++ b/StyleGuide-iOS/StyleGuide/Fonts/README (Fonts).md
@@ -1,17 +1,19 @@
 
+# FONTS
+
+
+The following fonts are included in this style guide:
+**OpenSans**
+
 Add the **Fonts provided by application** key to your app's **Info.plist** file.
 
 List the fonts used by your app ...
-**OpenSans-Bold.ttf**
-**OpenSans-BoldItalic.ttf**
-**OpenSans-ExtraBold.ttf**
-**OpenSans-ExtraBoldItalic.ttf**
-**OpenSans-Italic.ttf**
-**OpenSans-Light.ttf**
-**OpenSans-LightItalic.ttf**
 **OpenSans-Regular.ttf**
-**OpenSans-Semibold.ttf**
-**OpenSans-SemiboldItalic.ttf**
+
+In `AppDelegate`'s `didFinishLaunchingWithOptions` method, call `loadFonts` in Swift using ...
+`AllinsonStyleGuide.loadFonts()`
+or in Objective-C using ...
+`[AllinsonStyleGuide loadFonts];`
 
 Set fonts programatically in Swift using ...
 **UIFont.Allinson.open_sans_small**

--- a/StyleGuide-iOS/StyleGuide/Fonts/UIFont+Allinson.swift
+++ b/StyleGuide-iOS/StyleGuide/Fonts/UIFont+Allinson.swift
@@ -18,7 +18,6 @@ public extension UIFont {
         public static var open_sans_medium: UIFont = UIFont(name: "OpenSans", size: 13.0) ?? UIFont.systemFont(ofSize: 13.0)
         public static var open_sans_large: UIFont = UIFont(name: "OpenSans", size: 15.0) ?? UIFont.systemFont(ofSize: 15.0)
         public static var open_sans_extralarge: UIFont = UIFont(name: "OpenSans", size: 17.0) ?? UIFont.systemFont(ofSize: 17.0)
-        
         public static var chalkduster_large: UIFont = UIFont(name: "Chalkduster", size: 20.0) ?? UIFont.systemFont(ofSize: 20.0)
         public static var chalkduster_extralarge: UIFont = UIFont(name: "Chalkduster", size: 40.0) ?? UIFont.systemFont(ofSize: 40.0)
     }

--- a/StyleGuide-iOS/StyleGuide/Images/README (Images).md
+++ b/StyleGuide-iOS/StyleGuide/Images/README (Images).md
@@ -1,4 +1,7 @@
 
+# IMAGES
+
+
 The following images are included in this style guide:
 **Allinson_logo**
 **Allinson_header_shadow**


### PR DESCRIPTION
This change now has the user call `loadFonts` on our `AllinsonStyleGuide` object in order to be able to use the fonts included in the Allinson-StyleGuide library.

- Add font loading inside our library with a `loadFonts` method required to be called in AppDelegate
- Updated README files
- Updated podspec